### PR TITLE
Make clear the perils of mixing trim and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ val db = Database.connect("jdbc:postgresql://localhost/wait_what", "myaccount", 
 case class GetAge(name: String) extends FlatSingleRowQuery[Int] {
 
   val sql = trim("""
-      SELECT age
+      SELECT age /* Use C-style comments in trimmed queries */
       FROM people
       WHERE name = ?
       """)

--- a/src/main/scala/com/simple/jdub/SqlBase.scala
+++ b/src/main/scala/com/simple/jdub/SqlBase.scala
@@ -1,5 +1,13 @@
 package com.simple.jdub
 
 trait SqlBase extends Instrumented {
+  /**
+   * Collapse all strings of whitespace into a single space.
+   *
+   * This function is incompatible with SQL standard comments (-- comment).
+   * Use C-style comments instead.
+   *
+   * @param sql the string to trim
+   */
   protected def trim(sql: String) = sql.replaceAll("""[\s]+""", " ").trim
 }

--- a/src/test/scala/com/simple/jdub/tests/DatabaseSpec.scala
+++ b/src/test/scala/com/simple/jdub/tests/DatabaseSpec.scala
@@ -264,7 +264,7 @@ class DatabaseSpec extends Spec {
         case class GetAge(name: String) extends FlatSingleRowQuery[Int] {
 
           val sql = trim("""
-              SELECT age
+              SELECT age /* Use C-style comments in trimmed queries */
               FROM people
               WHERE name = ?
               """)

--- a/tour.md
+++ b/tour.md
@@ -34,6 +34,8 @@ val sql = trim("""
     """)
 ```
 
+Note that `trim` will break any query using SQL-standard comments (`-- comment`). Use C-style comments instead (`/* comment */`).
+
 ### Bind Parameters and Security
 Bind parameters are used to pass values into SQL statements. The values are taken from the `values` field. If the same value is needed multiple times in the query, simply provide it multiple times when setting `values`:
 


### PR DESCRIPTION
Supercedes https://github.com/SimpleFinance/jdub/pull/42. Instead of a janky solution to try to make `trim` play nice with comments, this PR just peppers in some warnings about `trim`'s behavior and suggests C-style comments as a solution.