### PR TITLE
Translate SQL array to Java array via casting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.simple</groupId>
     <artifactId>jdub_2.11</artifactId>
-    <version>1.1.1</version>
+    <version>1.2.0</version>
     <name>Jdub for Scala ${scala.version}</name>
     <url>https://github.com/SimpleFinance/jdub</url>
     <description>Jdub is a Scala wrapper over JDBC.</description>

--- a/src/main/scala/com/simple/jdub/Row.scala
+++ b/src/main/scala/com/simple/jdub/Row.scala
@@ -308,18 +308,17 @@ class Row(rs: ResultSet) {
 
   private[this] def extract[A](f: A): Option[A] = if (rs.wasNull()) None else Some(f)
 
-  def array[T: reflect.ClassTag](index: Int): Array[T] = extractArray[T](rs.getArray(index + 1))
+  def array[T: reflect.ClassTag](index: Int): Option[Array[T]] = extractArray[T](rs.getArray(index + 1))
 
-  def array[T: reflect.ClassTag](name: String): Array[T] = extractArray[T](rs.getArray(name))
+  def array[T: reflect.ClassTag](name: String): Option[Array[T]] = extractArray[T](rs.getArray(name))
 
-  private[this] def extractArray[T: reflect.ClassTag](sqlArray: java.sql.Array): Array[T] = {
+  private[this] def extractArray[T: reflect.ClassTag](sqlArray: java.sql.Array): Option[Array[T]] = {
     if (rs.wasNull()) {
-      Array.empty[T]
+      None
     } else {
-      sqlArray
-        .getArray
-        .asInstanceOf[Array[Object]]
-        .map(_.asInstanceOf[T])
+      Option(sqlArray.getArray
+                     .asInstanceOf[Array[Object]]
+                     .map(_.asInstanceOf[T]))
     }
   }
 }

--- a/src/main/scala/com/simple/jdub/Row.scala
+++ b/src/main/scala/com/simple/jdub/Row.scala
@@ -306,5 +306,20 @@ class Row(rs: ResultSet) {
     colNames.zip(colValues).toMap
   }
 
-  private def extract[A](f: A): Option[A] = if (rs.wasNull()) None else Some(f)
+  private[this] def extract[A](f: A): Option[A] = if (rs.wasNull()) None else Some(f)
+
+  def array[T: reflect.ClassTag](index: Int): Array[T] = extractArray[T](rs.getArray(index + 1))
+
+  def array[T: reflect.ClassTag](name: String): Array[T] = extractArray[T](rs.getArray(name))
+
+  private[this] def extractArray[T: reflect.ClassTag](sqlArray: java.sql.Array): Array[T] = {
+    if (rs.wasNull()) {
+      Array.empty[T]
+    } else {
+      sqlArray
+        .getArray
+        .asInstanceOf[Array[Object]]
+        .map(_.asInstanceOf[T])
+    }
+  }
 }

--- a/src/test/scala/com/simple/jdub/tests/DatabaseSpec.scala
+++ b/src/test/scala/com/simple/jdub/tests/DatabaseSpec.scala
@@ -55,6 +55,26 @@ class DatabaseSpec extends Spec {
                                       "AGE" -> 402))))
     }
 
+    @Test def `returns an array of strings` = {
+      db(NamesArrayQuery())
+        .map(_.toSeq) // arrays compare by reference, seqs by value
+        .must(be(Seq(Seq("Coda Hale",
+                         "Kris Gale",
+                         "Old Guy"))))
+    }
+
+    @Test def `returns an array of integers` = {
+      db(AgesArrayQuery())
+        .map(_.toSeq) // arrays compare by reference, seqs by value
+        .must(be(Seq(Seq(29, 30, 402))))
+    }
+
+    @Test def `returns an empty array` = {
+      db(EmptyArrayQuery())
+        .map(_.toSeq) // arrays compare by reference, seqs by value
+        .must(be(Seq(Seq())))
+    }
+
     class `transaction` {
       @Test def `commits by default` = {
         db.transaction { txn =>
@@ -377,4 +397,28 @@ case class MapsQuery() extends CollectionQuery[Seq, Map[String, Any]] {
   val values = Seq()
 
   def map(row: Row) = row.toMap
+}
+
+case class NamesArrayQuery() extends CollectionQuery[Seq, Array[String]] {
+  val sql = trim("SELECT ARRAY_AGG(name) AS names FROM people")
+
+  val values = Seq()
+
+  def map(row: Row) = row.array[String]("names")
+}
+
+case class AgesArrayQuery() extends CollectionQuery[Seq, Array[Int]] {
+  val sql = trim("SELECT ARRAY_AGG(age) AS ages FROM people")
+
+  val values = Seq()
+
+  def map(row: Row) = row.array[Int]("ages")
+}
+
+case class EmptyArrayQuery() extends CollectionQuery[Seq, Array[Int]] {
+  val sql = trim("SELECT ARRAY_AGG(age) AS ages FROM people WHERE name = 'not a name'")
+
+  val values = Seq()
+
+  def map(row: Row) = row.array[Int]("ages")
 }

--- a/src/test/scala/com/simple/jdub/tests/DatabaseSpec.scala
+++ b/src/test/scala/com/simple/jdub/tests/DatabaseSpec.scala
@@ -57,22 +57,24 @@ class DatabaseSpec extends Spec {
 
     @Test def `returns an array of strings` = {
       db(NamesArrayQuery())
-        .map(_.toSeq) // arrays compare by reference, seqs by value
-        .must(be(Seq(Seq("Coda Hale",
-                         "Kris Gale",
-                         "Old Guy"))))
+        .map(_.map(_.toSeq)) // arrays compare by reference, seqs by value
+        .must(be(Seq(Some(Seq("Coda Hale",
+                              "Kris Gale",
+                              "Old Guy")))))
     }
 
     @Test def `returns an array of integers` = {
       db(AgesArrayQuery())
-        .map(_.toSeq) // arrays compare by reference, seqs by value
-        .must(be(Seq(Seq(29, 30, 402))))
+        .map(_.map(_.toSeq)) // arrays compare by reference, seqs by value
+        .must(be(Seq(Some(Seq(29,
+                              30,
+                              402)))))
     }
 
     @Test def `returns an empty array` = {
       db(EmptyArrayQuery())
-        .map(_.toSeq) // arrays compare by reference, seqs by value
-        .must(be(Seq(Seq())))
+        .map(_.map(_.toSeq)) // arrays compare by reference, seqs by value
+        .must(be(Seq(None)))
     }
 
     class `transaction` {
@@ -399,7 +401,7 @@ case class MapsQuery() extends CollectionQuery[Seq, Map[String, Any]] {
   def map(row: Row) = row.toMap
 }
 
-case class NamesArrayQuery() extends CollectionQuery[Seq, Array[String]] {
+case class NamesArrayQuery() extends CollectionQuery[Seq, Option[Array[String]]] {
   val sql = trim("SELECT ARRAY_AGG(name) AS names FROM people")
 
   val values = Seq()
@@ -407,7 +409,7 @@ case class NamesArrayQuery() extends CollectionQuery[Seq, Array[String]] {
   def map(row: Row) = row.array[String]("names")
 }
 
-case class AgesArrayQuery() extends CollectionQuery[Seq, Array[Int]] {
+case class AgesArrayQuery() extends CollectionQuery[Seq, Option[Array[Int]]] {
   val sql = trim("SELECT ARRAY_AGG(age) AS ages FROM people")
 
   val values = Seq()
@@ -415,7 +417,7 @@ case class AgesArrayQuery() extends CollectionQuery[Seq, Array[Int]] {
   def map(row: Row) = row.array[Int]("ages")
 }
 
-case class EmptyArrayQuery() extends CollectionQuery[Seq, Array[Int]] {
+case class EmptyArrayQuery() extends CollectionQuery[Seq, Option[Array[Int]]] {
   val sql = trim("SELECT ARRAY_AGG(age) AS ages FROM people WHERE name = 'not a name'")
 
   val values = Seq()


### PR DESCRIPTION
Allows users to consume SQL arrays more-or-less directly as the Scala
type they choose. Under the hood, it uses a cast to translate the
`java.sql.Array` object's contents to your desired type.

This is somewhat more dangerous than most of the type coercion performed
by `jdub`, as it's not being translated through the `ResultSet` object. It
may be advisable to handle possible type exceptions when using this
method.