### PR TITLE
Introduce per connection init SQL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.simple</groupId>
     <artifactId>jdub_2.11</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
     <name>Jdub for Scala ${scala.version}</name>
     <url>https://github.com/SimpleFinance/jdub</url>
     <description>Jdub is a Scala wrapper over JDBC.</description>
@@ -14,7 +14,7 @@
     <properties>
         <scala.major.version>2.11</scala.major.version>
         <scala.version>${scala.major.version}.4</scala.version>
-        <metrics.version>3.1.1</metrics.version>
+        <metrics.version>3.1.2</metrics.version>
     </properties>
 
     <developers>
@@ -95,7 +95,7 @@
         <dependency>
           <groupId>com.zaxxer</groupId>
           <artifactId>HikariCP-java6</artifactId>
-          <version>2.3.5</version>
+          <version>2.3.9</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>
@@ -116,13 +116,13 @@
         <dependency>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
-            <version>2.2.8</version>
+            <version>2.3.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.0.13</version>
+            <version>1.1.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/scala/com/simple/jdub/Database.scala
+++ b/src/main/scala/com/simple/jdub/Database.scala
@@ -29,7 +29,8 @@ object Database {
               jdbcProperties: Map[String, String] = Map.empty,
               sslSettings: Option[SslSettings] = None,
               healthCheckRegistry: Option[HealthCheckRegistry] = None,
-              metricRegistry: Option[MetricRegistry] = None): Database = {
+              metricRegistry: Option[MetricRegistry] = None,
+              connectionInitSql: Option[String] = None): Database = {
 
     val properties = new Properties
 
@@ -51,6 +52,7 @@ object Database {
       setMaximumPoolSize(maxSize)
       healthCheckRegistry.map(setHealthCheckRegistry)
       metricRegistry.map(setMetricRegistry)
+      connectionInitSql.map(setConnectionInitSql)
     }
 
     val poolDataSource  = new HikariDataSource(poolConfig)


### PR DESCRIPTION
Hikaricp supports some arbitrary SQL to be executed whenever a new
connection is added to the pool. This allows jdub to support that.