### PR TITLE
Add savepoint capability to transactions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.simple</groupId>
     <artifactId>jdub_2.11</artifactId>
-    <version>1.3.1</version>
+    <version>1.3.2</version>
     <name>Jdub for Scala ${scala.version}</name>
     <url>https://github.com/SimpleFinance/jdub</url>
     <description>Jdub is a Scala wrapper over JDBC.</description>

--- a/src/main/scala/com/simple/jdub/Transaction.scala
+++ b/src/main/scala/com/simple/jdub/Transaction.scala
@@ -1,6 +1,6 @@
 package com.simple.jdub
 
-import java.sql.Connection
+import java.sql.{Connection, Savepoint}
 import scala.collection.mutable.ListBuffer
 
 class Transaction(connection: Connection) extends Queryable {
@@ -24,6 +24,38 @@ class Transaction(connection: Connection) extends Queryable {
     connection.rollback()
     rolledback = true
     onRollback.foreach(_())
+  }
+
+  /**
+   * Roll back the transaction to a savepoint.
+   */
+  def rollback(savepoint: Savepoint) {
+    logger.debug("Rolling back to savepoint")
+    connection.rollback(savepoint)
+  }
+
+  /**
+   * Release a transaction from a savepoint.
+   */
+  def release(savepoint: Savepoint) {
+    logger.debug("Releasing savepoint")
+    connection.rollback(savepoint)
+  }
+
+  /**
+   * Set an unnamed savepoint.
+   */
+  def savepoint(): Savepoint = {
+    logger.debug("Setting unnamed savepoint")
+    connection.setSavepoint()
+  }
+
+  /**
+   * Set a named savepoint.
+   */
+  def savepoint(name: String): Savepoint = {
+    logger.debug("Setting savepoint")
+    connection.setSavepoint(name)
   }
 
   private[jdub] def commit() {


### PR DESCRIPTION
JDBC support savepoints natively. See java.sql.Connection for more
details. This commit adds the ability for jdub managed transactions to
set, release, and rollback named and unnamed savepoints.