### PR TITLE
Add quiet transaction scopes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.simple</groupId>
     <artifactId>jdub_2.11</artifactId>
-    <version>0.10.0</version>
+    <version>0.11.0</version>
     <name>Jdub for Scala ${scala.version}</name>
     <url>https://github.com/SimpleFinance/jdub</url>
     <description>Jdub is a Scala wrapper over JDBC.</description>


### PR DESCRIPTION
This functionality dovetails well with the `quietTransaction` method
defined earlier and allows users to declare transaction scopes which
will quietly rollback on errors. The supplied function `f` for these
methods is expected to log errors if desired.
