### PR TITLE
Don't increment index twice for UUIDs

### DIFF
--- a/src/main/scala/com/simple/jdub/Row.scala
+++ b/src/main/scala/com/simple/jdub/Row.scala
@@ -23,7 +23,7 @@ class Row(rs: ResultSet) {
   /**
    * Extract the value at the given offset as an Option[UUID].
    */
-  def uuid(index: Int) = string(index + 1).map { UUID.fromString }
+  def uuid(index: Int) = string(index).map { UUID.fromString }
 
   /**
    * Extract the value with the given name as an Option[UUID].


### PR DESCRIPTION
Both `uuid` and `string` increment the index causing erroneous column indexes to be used.