### PR TITLE
SQL Interpolator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,9 +12,10 @@
     <description>Jdub is a Scala wrapper over JDBC.</description>
 
     <properties>
+        <hikaricp.version>2.4.5</hikaricp.version>
+        <metrics.version>3.1.2</metrics.version>
         <scala.major.version>2.11</scala.major.version>
         <scala.version>${scala.major.version}.7</scala.version>
-        <metrics.version>3.1.2</metrics.version>
     </properties>
 
     <developers>
@@ -95,7 +96,7 @@
         <dependency>
           <groupId>com.zaxxer</groupId>
           <artifactId>HikariCP</artifactId>
-          <version>2.4.3</version>
+          <version>${hikaricp.version}</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.simple</groupId>
     <artifactId>jdub_2.11</artifactId>
-    <version>1.3.3</version>
+    <version>1.3.4</version>
     <name>Jdub for Scala ${scala.version}</name>
     <url>https://github.com/SimpleFinance/jdub</url>
     <description>Jdub is a Scala wrapper over JDBC.</description>

--- a/src/main/scala/com/simple/jdub/Interpolator.scala
+++ b/src/main/scala/com/simple/jdub/Interpolator.scala
@@ -1,0 +1,86 @@
+/**
+ * © 2016 Simple Finance Technology Corp. All rights reserved.
+ */
+
+package com.simple.jdub
+
+object Interpolator {
+  case class Statements private[jdub] (
+    sql: String,
+    values: Seq[Any]
+  ) extends Statement
+
+  case class CollectionQueries[T] private[jdub] (
+    sql: String,
+    values: Seq[Any],
+    f: Row => T
+  ) extends CollectionQuery[Seq, T] {
+    def map(row: Row) = f(row)
+  }
+
+  case class FlatCollectionQueries[T] private[jdub] (
+    sql: String,
+    values: Seq[Any],
+    f: Row => Option[T]
+  ) extends FlatCollectionQuery[Seq, T] {
+    def flatMap(row: Row) = f(row)
+  }
+
+  case class Queries[T] private[jdub] (
+    sql: String,
+    values: Seq[Any],
+    initial: T,
+    f: (T, Row) => T
+  ) extends Query[T] {
+    def reduce(rows: Iterator[Row]): T = rows.foldLeft(initial)(f)
+  }
+
+  implicit class SqlStringContext(val query: StringContext) extends AnyVal {
+    def sql(params: Any*) = Statements(
+      sql = expand(params, query.parts),
+      values = pancake(params)
+    )
+  }
+
+  implicit class SqlStatement(val statement: Statement) extends AnyVal {
+    def map[T](f: Row => T) = CollectionQueries[T](
+      sql = statement.sql,
+      values = statement.values,
+      f = f
+    )
+
+    def flatMap[T](f: Row => Option[T]) = FlatCollectionQueries[T](
+      sql = statement.sql,
+      values = statement.values,
+      f = f
+    )
+
+    def foldLeft[T](initial: T)(f: (T, Row) => T) = Queries[T](
+      sql = statement.sql,
+      values = statement.values,
+      initial = initial,
+      f = f
+    )
+  }
+
+  private def expand(params: Seq[Any], parts: Seq[String]): String = {
+    val builder = new StringBuilder
+    builder.append(parts.head)
+    params.zip(parts.tail).map {
+      case (param, part) =>
+        builder.append(("?" * size(param)).mkString(", "))
+        builder.append(part)
+    }
+    builder.toString
+  }
+
+  private def size(param: Any): Int = param match {
+    case seq: Seq[_] => seq.length
+    case _ => 1
+  }
+
+  private def pancake(params: Seq[Any]): Seq[Any] = params.flatMap {
+    case seq: Seq[_] => seq // only support lists nested one deep
+    case param => Seq(param)
+  }
+}


### PR DESCRIPTION
Add a SQL String Interpolator. Does all the building of queries/etc. for you.

Possible Usage:

```scala
import com.simple.jdub.Database
import com.simple.jdub.Interpolator

case class Record(id: String, name: String)

object RecordQueries {
  def mapper(row: Row): Record = {
    Record(
      id = row.string("id").get
      name = row.string("name").get
  }
}

class RecordQueries(val database: Database) {
  def getRecord(id: String): Option[Record] = database {
    sql"""
      SELECT id, name
      FROM   records
      WHERE id = ${id}
    """.map(RecordQueries.mapper)
  }.headOption
}
```

Also bumped the `HikariCP` version to the latest point release, `2.4.5`