### PR TITLE
[jdub] 2.11 jdk8 backport

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: scala
 scala:
-  - 2.9.2
+  - 2.11.8
+jdk:
+  - oraclejdk8
 install: true
 script:
   - "mvn test"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ jdub
 Requirements
 ------------
 
-* Java SE 6 or above
+* Java SE 8 or above
 * Scala 2.11.x
 
 How To Use
@@ -180,6 +180,6 @@ License
 -------
 
 Copyright (c) 2011-2012 Coda Hale
-Copyright (c) 2012-2016 Simple Finance Technology Corp. All rights reserved.
+Copyright (c) 2012-2017 Simple Finance Technology Corp. All rights reserved.
 
 Published under The MIT License, see [LICENSE.md](LICENSE.md)

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.simple</groupId>
     <artifactId>jdub_2.11</artifactId>
-    <version>1.5.0</version>
+    <version>1.5.0-SNAPSHOT</version>
     <name>Jdub for Scala ${scala.version}</name>
     <url>https://github.com/SimpleFinance/jdub</url>
     <description>Jdub is a Scala wrapper over JDBC.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,32 +6,32 @@
 
     <groupId>com.simple</groupId>
     <artifactId>jdub_2.11</artifactId>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <name>Jdub for Scala ${scala.version}</name>
     <url>https://github.com/SimpleFinance/jdub</url>
     <description>Jdub is a Scala wrapper over JDBC.</description>
 
     <properties>
-        <grizzled-slf4j.version>1.2.0</grizzled-slf4j.version>
-        <hikaricp-java7.version>2.4.9</hikaricp-java7.version>
-        <hsqldb.version>2.3.3</hsqldb.version>
-        <joda-convert.version>1.7</joda-convert.version>
-        <joda-time.version>2.9.1</joda-time.version>
-        <logback.version>1.1.7</logback.version>
-        <maven-compiler-plugin.version>3.2</maven-compiler-plugin.version>
-        <maven-gpg-plugin.version>1.5</maven-gpg-plugin.version>
-        <maven-javadoc-plugin.version>2.9.1</maven-javadoc-plugin.version>
-        <maven-resources-plugin.version>2.6</maven-resources-plugin.version>
-        <maven-source-plugin.version>2.2.1</maven-source-plugin.version>
-        <maven-surefire-plugin.version>2.17</maven-surefire-plugin.version>
+        <grizzled-slf4j.version>1.3.0</grizzled-slf4j.version>
+        <hikaricp.version>2.6.1</hikaricp.version>
+        <hsqldb.version>2.3.4</hsqldb.version>
+        <joda-convert.version>1.8.1</joda-convert.version>
+        <joda-time.version>2.9.9</joda-time.version>
+        <logback.version>1.2.2</logback.version>
+        <maven-compiler-plugin.version>3.6.0</maven-compiler-plugin.version>
+        <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
+        <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
+        <maven-resources-plugin.version>3.0.2</maven-resources-plugin.version>
+        <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
+        <maven-surefire-plugin.version>2.19.1</maven-surefire-plugin.version>
         <metrics.version>3.1.2</metrics.version>
-        <mockito.version>1.9.5</mockito.version>
+        <mockito.version>1.10.19</mockito.version>
         <scala.major.version>2.11</scala.major.version>
         <scala.version>${scala.major.version}.8</scala.version>
-        <scala-maven-plugin.version>3.2.0</scala-maven-plugin.version>
-        <scalatest.version>3.0.0</scalatest.version>
+        <scala-maven-plugin.version>3.2.2</scala-maven-plugin.version>
+        <scalatest.version>3.0.1</scalatest.version>
         <scalatest-maven-plugin.version>1.0</scalatest-maven-plugin.version>
-        <wagon-ssh-external.version>2.6</wagon-ssh-external.version>
+        <wagon-ssh-external.version>2.10</wagon-ssh-external.version>
     </properties>
 
     <developers>
@@ -63,7 +63,7 @@
 
     <issueManagement>
         <system>github</system>
-        <url>http://github.com/SimpleFinance/jdub/issues#issue/</url>
+        <url>http://github.com/SimpleFinance/jdub/issues</url>
     </issueManagement>
 
     <repositories>
@@ -111,8 +111,8 @@
         </dependency>
         <dependency>
           <groupId>com.zaxxer</groupId>
-          <artifactId>HikariCP-java7</artifactId>
-          <version>${hikaricp-java7.version}</version>
+          <artifactId>HikariCP</artifactId>
+          <version>${hikaricp.version}</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>
@@ -204,8 +204,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>


### PR DESCRIPTION
This is a backport of most of the work done for 2.12 support and JDK8. There wasn't anything specific to the 2.12 update except the scala version bump in the pom.

This updates all the dependencies to what is in master + a couple additional bumps. Brings across the code changes and bumps the JDK to support 1.8

Finally, bumped the version of jdub to `1.5.0`