### PR TITLE
jdub, jdk8 time support for 2.12 lib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.simple</groupId>
     <artifactId>jdub_2.12</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <name>Jdub for Scala ${scala.version}</name>
     <url>https://github.com/SimpleFinance/jdub</url>
     <description>Jdub is a Scala wrapper over JDBC.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <hsqldb.version>2.3.4</hsqldb.version>
         <joda-convert.version>1.8.1</joda-convert.version>
         <joda-time.version>2.9.9</joda-time.version>
-        <logback.version>1.2.2</logback.version>
+        <logback.version>1.2.3</logback.version>
         <maven-compiler-plugin.version>3.6.0</maven-compiler-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -13,11 +13,11 @@
 
     <properties>
         <grizzled-slf4j.version>1.3.0</grizzled-slf4j.version>
-        <hikaricp.version>2.5.1</hikaricp.version>
+        <hikaricp.version>2.6.1</hikaricp.version>
         <hsqldb.version>2.3.4</hsqldb.version>
         <joda-convert.version>1.8.1</joda-convert.version>
-        <joda-time.version>2.9.7</joda-time.version>
-        <logback.version>1.1.8</logback.version>
+        <joda-time.version>2.9.9</joda-time.version>
+        <logback.version>1.2.2</logback.version>
         <maven-compiler-plugin.version>3.6.0</maven-compiler-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
@@ -63,7 +63,7 @@
 
     <issueManagement>
         <system>github</system>
-        <url>http://github.com/SimpleFinance/jdub/issues#issue/</url>
+        <url>http://github.com/SimpleFinance/jdub/issues</url>
     </issueManagement>
 
     <repositories>

--- a/src/test/scala/com/simple/jdub/tests/UtilsSpec.scala
+++ b/src/test/scala/com/simple/jdub/tests/UtilsSpec.scala
@@ -2,22 +2,36 @@ package com.simple.jdub.tests
 
 import com.simple.jdub._
 
-import org.joda.time.DateTime
-import org.joda.time.LocalDate
 import org.mockito.Mockito.verify
 
 import java.sql
 import scala.math.BigDecimal
 
 class UtilsSpec extends JdubSpec {
-  test("DateTime is converted properly") {
-    val converted = Utils.convert(DateTime.now())
+  test("joda - DateTime is converted properly") {
+    val converted = Utils.convert(org.joda.time.DateTime.now())
     converted.isInstanceOf[java.sql.Timestamp].must(be(true))
   }
 
-  test("LocalDate is converted properly") {
-    val converted = Utils.convert(LocalDate.now())
+  test("joda - LocalDate is converted properly") {
+    val converted = Utils.convert(org.joda.time.LocalDate.now())
     converted.isInstanceOf[java.sql.Date].must(be(true))
+  }
+
+  test("jdk - LocalDateTime is converted properly") {
+    val jdkDateTime = java.time.LocalDateTime.now()
+    val converted = Utils.convert(jdkDateTime)
+
+    converted.isInstanceOf[java.sql.Timestamp].must(be(true))
+    converted.asInstanceOf[java.sql.Timestamp].toLocalDateTime.mustBe(jdkDateTime)
+  }
+
+  test("jdk - LocalDate is converted properly") {
+    val jdkDate = java.time.LocalDate.now()
+    val converted = Utils.convert(jdkDate)
+
+    converted.isInstanceOf[java.sql.Date].must(be(true))
+    converted.asInstanceOf[java.sql.Date].toLocalDate.mustBe(jdkDate)
   }
 
   test("BigDecimal is converted property") {


### PR DESCRIPTION
- port 2.11 jdk8 time support
- dependency syncing

pulls in changes from #64 & #65 